### PR TITLE
Remove default features from image crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,14 @@ test-fail-warning = []
 
 [dependencies]
 thiserror = "1.0.26"
-image = "0.23.14"
 mozjpeg = "0.8.24"
 flume = "0.10.5"
 usb_enumeration = "0.1.2"
 paste = "1.0.5"
+
+[dependencies.image]
+version = "0.23.14"
+default-features = false
 
 [dependencies.v4l]
 version = "0.12.1"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,6 +58,7 @@ impl From<MFFrameFormat> for FrameFormat {
     }
 }
 
+#[cfg(feature = "input-msmf")]
 impl From<FrameFormat> for MFFrameFormat {
     fn from(ff: FrameFormat) -> Self {
         match ff {


### PR DESCRIPTION
Removes a lot of additional crate dependencies that are pulled in by default.

Those crates aren't really necessary if only the generic image buffer is used.
(unless I overlooked something, only built it on Linux)
