### PR TITLE
Feature boxed callback

### DIFF
--- a/examples/threaded-capture/src/main.rs
+++ b/examples/threaded-capture/src/main.rs
@@ -15,13 +15,13 @@
  */
 
 use image::{ImageBuffer, Rgb};
-use nokhwa::{query_devices, CallbackCamera, CaptureAPIBackend};
+use nokhwa::{query_devices, CallbackCamera, CameraIndex, CaptureAPIBackend};
 
 fn main() {
     let cameras = query_devices(CaptureAPIBackend::Auto).unwrap();
     cameras.iter().for_each(|cam| println!("{:?}", cam));
 
-    let mut threaded = CallbackCamera::new(0, None).unwrap();
+    let mut threaded = CallbackCamera::new(&CameraIndex::Index(0), None).unwrap();
     threaded.open_stream(callback).unwrap();
     #[allow(clippy::empty_loop)] // keep it running
     loop {

--- a/src/query.rs
+++ b/src/query.rs
@@ -146,7 +146,7 @@ fn query_v4l() -> Result<Vec<CameraInfo>, NokhwaError> {
 }
 
 #[cfg(any(not(feature = "input-v4l"), not(target_os = "linux")))]
-fn query_v4l<'a>() -> Result<Vec<CameraInfo<'a>>, NokhwaError> {
+fn query_v4l() -> Result<Vec<CameraInfo>, NokhwaError> {
     Err(NokhwaError::UnsupportedOperationError(
         CaptureAPIBackend::Video4Linux,
     ))
@@ -287,7 +287,7 @@ fn query_gstreamer() -> Result<Vec<CameraInfo>, NokhwaError> {
 }
 
 #[cfg(not(feature = "input-gst"))]
-fn query_gstreamer<'a>() -> Result<Vec<CameraInfo<'a>>, NokhwaError> {
+fn query_gstreamer() -> Result<Vec<CameraInfo>, NokhwaError> {
     Err(NokhwaError::UnsupportedOperationError(
         CaptureAPIBackend::GStreamer,
     ))


### PR DESCRIPTION
This pull request consists of two cosmetic changes and a new feature:

**Remove not necessary lifetime specifiers**: Rust didn't let me compile my code with them in place, so remove them
```
error[E0107]: this struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> nokhwa/src/query.rs:290:40
    |
290 | fn query_gstreamer<'a>() -> Result<Vec<CameraInfo<'a>>, NokhwaError> {
    |                                        ^^^^^^^^^^---- help: remove these generics
    |                                        |
    |                                        expected 0 lifetime arguments
```
**Fix threaded example camera index**: Seems as new `CameraIndex` didn't yet make it into example code, fixed this.

**Add boxed callback for CallbackCamera**: Currently, `CallbackCamera` only accepts a function as callback. Why not make it more flexible to accept an `Box<dyn FnMut()>`? This can take a function as usual (so no need to change existing code), but this can e.g. also take a closure!
Tested using my own code (passing a closure); tested using example code (passing a function).
