### PR TITLE
Fixed in-buffer frame decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ decoding = ["mozjpeg"]
 input-v4l = ["v4l", "v4l2-sys-mit"]
 input-msmf = ["nokhwa-bindings-windows"]
 input-avfoundation = ["nokhwa-bindings-macos"]
-input-uvc = ["uvc", "uvc/vendor", "ouroboros", "usb_enumeration", "lazy_static"]
+# Re-enable it once soundness has been proven + mozjpeg is updated to 0.9.x
+# input-uvc = ["uvc", "uvc/vendor", "ouroboros", "usb_enumeration", "lazy_static"]
 input-opencv = ["opencv", "opencv/clang-runtime"]
 input-ipcam = ["input-opencv"]
 input-gst = ["gstreamer", "glib", "gstreamer-app", "gstreamer-video", "regex", "parking_lot"]
@@ -28,80 +29,81 @@ output-wgpu = ["wgpu"]
 output-wasm = ["input-jscam"]
 output-threaded = ["parking_lot"]
 small-wasm = ["wee_alloc"]
-docs-only = ["input-uvc", "input-v4l", "input-opencv", "input-ipcam", "input-gst", "input-msmf", "input-avfoundation", "input-jscam","output-wgpu", "output-wasm", "output-threaded"]
+docs-only = ["input-v4l", "input-opencv", "input-ipcam", "input-gst", "input-msmf", "input-avfoundation", "input-jscam","output-wgpu", "output-wasm", "output-threaded"]
 docs-nolink = ["glib/dox", "gstreamer-app/dox", "gstreamer/dox", "gstreamer-video/dox", "opencv/docs-only"]
 docs-features = []
 test-fail-warning = []
 
 [dependencies]
-thiserror = "1.0.26"
-paste = "1.0.5"
+thiserror = "1.0"
+paste = "1.0"
 
 [dependencies.flume]
-version = "0.10.9"
+version = "0.10"
 optional = true
 
 [dependencies.image]
-version = "^0.23"
+version = "0.23"
 default-features = false
 
 [target.'cfg(not(target_arch = "wasm"))'.dependencies.mozjpeg]
-version = "0.8.24"
+git = "https://github.com/otak/mozjpeg-rust"
+branch = "otak/read_scanlines_into"
 optional = true
 
 [target.'cfg(target_os = "linux")'.dependencies.v4l]
-version = "0.12.1"
+version = "0.12"
 optional = true
 
 [target.'cfg(target_os = "linux")'.dependencies.v4l2-sys-mit]
-version = "0.2.0"
+version = "0.2"
 optional = true
 
 [dependencies.ouroboros]
-version = "^0.13"
+version = "0.14"
 optional = true
 
-[dependencies.uvc]
-version = "0.2.0"
-optional = true
+# [dependencies.uvc]
+# version = "0.2"
+# optional = true
 
 [dependencies.usb_enumeration]
 version = "0.1.2"
 optional = true
 
 [dependencies.wgpu]
-version = "^0.11"
+version = "^0.12"
 optional = true
 
 [dependencies.opencv]
-version = "0.60.0"
+version = "0.62"
 features = ["clang-runtime"]
 optional = true
 
 [dependencies.nokhwa-bindings-windows]
-version = "0.3.3"
+version = "0.3"
 path = "nokhwa-bindings-windows"
 optional = true
 
 [dependencies.nokhwa-bindings-macos]
-version = "0.1.1"
+version = "0.1"
 path = "nokhwa-bindings-macos"
 optional = true
 
 [dependencies.gstreamer]
-version = "0.17.0"
+version = "0.18"
 optional = true
 
 [dependencies.gstreamer-app]
-version = "0.17.0"
+version = "0.18"
 optional = true
 
 [dependencies.gstreamer-video]
-version = "0.17.0"
+version = "0.18"
 optional = true
 
 [dependencies.glib]
-version = "0.14.0"
+version = "0.15"
 optional = true
 
 [dependencies.regex]
@@ -109,7 +111,7 @@ version = "1.4.6"
 optional = true
 
 [dependencies.web-sys]
-version = "^0.3"
+version = "0.3"
 # why
 features = [
     "console",
@@ -130,31 +132,31 @@ features = [
 optional = true
 
 [dependencies.js-sys]
-version = "^0.3"
+version = "0.3"
 optional = true
 
 [dependencies.wasm-bindgen]
-version = "^0.2"
+version = "0.2"
 optional = true
 
 [dependencies.wasm-bindgen-futures]
-version = "^0.4"
+version = "0.4"
 optional = true
 
 [dependencies.wasm-rs-async-executor]
-version = "^0.9"
+version = "0.9"
 optional = true
 
 [dependencies.wee_alloc]
-version = "0.4.5"
+version = "0.4"
 optional = true
 
 [dependencies.parking_lot]
-version = "^0.11"
+version = "0.11"
 optional = true
 
 [dependencies.lazy_static]
-version = "^1.4"
+version = "1.4"
 optional = true
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,7 @@ version = "0.23"
 default-features = false
 
 [target.'cfg(not(target_arch = "wasm"))'.dependencies.mozjpeg]
-git = "https://github.com/otak/mozjpeg-rust"
-branch = "otak/read_scanlines_into"
+version = "0.9"
 optional = true
 
 [target.'cfg(target_os = "linux")'.dependencies.v4l]

--- a/src/backends/capture/avfoundation.rs
+++ b/src/backends/capture/avfoundation.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::{
-    mjpeg_to_rgb888, yuyv422_to_rgb888, CameraControl, CameraFormat, CameraIndex, CameraInfo,
+    mjpeg_to_rgb, yuyv422_to_rgb, CameraControl, CameraFormat, CameraIndex, CameraInfo,
     CaptureAPIBackend, CaptureBackendTrait, FrameFormat, KnownCameraControls, NokhwaError,
     Resolution,
 };
@@ -299,8 +299,8 @@ impl CaptureBackendTrait for AVFoundationCaptureDevice {
             Some(collector) => {
                 let data = collector.frame_to_slice()?;
                 let data = match data.1 {
-                    AVFourCC::YUV2 => Cow::from(yuyv422_to_rgb888(data.0.borrow())),
-                    AVFourCC::MJPEG => Cow::from(mjpeg_to_rgb888(data.0.borrow())),
+                    AVFourCC::YUV2 => Cow::from(yuyv422_to_rgb(data.0.borrow(), false)),
+                    AVFourCC::MJPEG => Cow::from(mjpeg_to_rgb(data.0.borrow(), false)),
                 };
                 Ok(data)
             }

--- a/src/backends/capture/gst_backend.rs
+++ b/src/backends/capture/gst_backend.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::{
-    mjpeg_to_rgb888, yuyv422_to_rgb888, CameraControl, CameraFormat, CameraIndex, CameraInfo,
+    mjpeg_to_rgb, yuyv422_to_rgb, CameraControl, CameraFormat, CameraIndex, CameraInfo,
     CaptureAPIBackend, CaptureBackendTrait, FrameFormat, KnownCameraControls, NokhwaError,
     Resolution,
 };
@@ -709,7 +709,7 @@ fn generate_pipeline(fmt: CameraFormat, index: usize) -> Result<PipelineGenRet, 
 
                 let image_buffer = match video_info.format() {
                     VideoFormat::Yuy2 => {
-                        let mut decoded_buffer = match yuyv422_to_rgb888(&buffer_map) {
+                        let mut decoded_buffer = match yuyv422_to_rgb(&buffer_map, false) {
                             Ok(buf) => buf,
                             Err(why) => {
                                 element_error!(
@@ -771,7 +771,7 @@ fn generate_pipeline(fmt: CameraFormat, index: usize) -> Result<PipelineGenRet, 
                     }
                     // MJPEG
                     VideoFormat::Encoded => {
-                        let mut decoded_buffer = match mjpeg_to_rgb888(&buffer_map) {
+                        let mut decoded_buffer = match mjpeg_to_rgb(&buffer_map, false) {
                             Ok(buf) => buf,
                             Err(why) => {
                                 element_error!(

--- a/src/backends/capture/msmf_backend.rs
+++ b/src/backends/capture/msmf_backend.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::{
-    all_known_camera_controls, mjpeg_to_rgb888, yuyv422_to_rgb888, CameraControl, CameraFormat,
+    all_known_camera_controls, mjpeg_to_rgb, yuyv422_to_rgb, CameraControl, CameraFormat,
     CameraIndex, CameraInfo, CaptureAPIBackend, CaptureBackendTrait, FrameFormat,
     KnownCameraControlFlag, KnownCameraControls, NokhwaError, Resolution,
 };
@@ -353,8 +353,8 @@ impl<'a> CaptureBackendTrait for MediaFoundationCaptureDevice<'a> {
         let camera_format = self.camera_format();
         let raw_data = self.frame_raw()?;
         let conv = match camera_format.format() {
-            FrameFormat::MJPEG => mjpeg_to_rgb888(raw_data.as_ref())?,
-            FrameFormat::YUYV => yuyv422_to_rgb888(raw_data.as_ref())?,
+            FrameFormat::MJPEG => mjpeg_to_rgb(raw_data.as_ref(), false)?,
+            FrameFormat::YUYV => yuyv422_to_rgb(raw_data.as_ref(), false)?,
         };
 
         let imagebuf =

--- a/src/backends/capture/v4l2_backend.rs
+++ b/src/backends/capture/v4l2_backend.rs
@@ -16,9 +16,9 @@
 
 use crate::{
     error::NokhwaError,
-    mjpeg_to_rgb888,
+    mjpeg_to_rgb,
     utils::{CameraFormat, CameraIndex, CameraInfo},
-    yuyv422_to_rgb888, CameraControl, CaptureAPIBackend, CaptureBackendTrait, FrameFormat,
+    yuyv422_to_rgb, CameraControl, CaptureAPIBackend, CaptureBackendTrait, FrameFormat,
     KnownCameraControlFlag, KnownCameraControls, Resolution,
 };
 use image::{ImageBuffer, Rgb};
@@ -686,8 +686,8 @@ impl<'a> CaptureBackendTrait for V4LCaptureDevice<'a> {
         let cam_fmt = self.camera_format;
         let raw_frame = self.frame_raw()?;
         let conv = match cam_fmt.format() {
-            FrameFormat::MJPEG => mjpeg_to_rgb888(&raw_frame)?,
-            FrameFormat::YUYV => yuyv422_to_rgb888(&raw_frame)?,
+            FrameFormat::MJPEG => mjpeg_to_rgb(&raw_frame, false)?,
+            FrameFormat::YUYV => yuyv422_to_rgb(&raw_frame, false)?,
         };
         let image_buf =
             match ImageBuffer::from_vec(cam_fmt.width(), cam_fmt.height(), conv) {

--- a/src/query.rs
+++ b/src/query.rs
@@ -146,7 +146,7 @@ fn query_v4l() -> Result<Vec<CameraInfo>, NokhwaError> {
 }
 
 #[cfg(any(not(feature = "input-v4l"), not(target_os = "linux")))]
-fn query_v4l<'a>() -> Result<Vec<CameraInfo<'a>>, NokhwaError> {
+fn query_v4l() -> Result<Vec<CameraInfo>, NokhwaError> {
     Err(NokhwaError::UnsupportedOperationError(
         CaptureAPIBackend::Video4Linux,
     ))
@@ -287,7 +287,7 @@ fn query_gstreamer() -> Result<Vec<CameraInfo>, NokhwaError> {
 }
 
 #[cfg(not(feature = "input-gst"))]
-fn query_gstreamer<'a>() -> Result<Vec<CameraInfo<'a>>, NokhwaError> {
+fn query_gstreamer() -> Result<Vec<CameraInfo>, NokhwaError> {
     Err(NokhwaError::UnsupportedOperationError(
         CaptureAPIBackend::GStreamer,
     ))


### PR DESCRIPTION
* Dropped UVC backend
* Updated mozjpeg to a forked 0.9.1 version supporting in-buffer decoding
	* Ideally a PR should be done to mozjpeg-rust to mainline this change
* Modified existing decoding methods to take rgba as a parameter
	* yuyv422_to_rgb888 / yuyv422_to_rgba => yuyv422_to_rgb
	* mozjpeg_to_rgb888 / mozjpeg_to_rgba => mozjpeg_to_rgb
* Added in-buffer decoding methods
	* buf_yuyv422_to_rgb
	* buf_mozjpeg_to_rgb
	* Note: the aforementioned existing decoding methods allocate a sizable `Vec` then call into those new methods.
* Simplified code in some places
* Removed `^version` in `Cargo.toml` dependencies as `^` is always implied
