### PR TITLE
Fix a assert failure with YUYV format

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1216,7 +1216,7 @@ pub fn yuyv422_to_rgb(data: &[u8], rgba: bool) -> Result<Vec<u8>, NokhwaError> {
     // yuyv yields 2 3-byte pixels per yuyv chunk
     let rgb_buf_size = (data.len() / 4) * (2 * pixel_size);
 
-    let mut dest = Vec::with_capacity(rgb_buf_size);
+    let mut dest = vec![0; rgb_buf_size];
     buf_yuyv422_to_rgb(data, &mut dest, rgba)?;
 
     Ok(dest)


### PR DESCRIPTION
Or it would always fail due to the `dest` length being 0.    
https://github.com/l1npengtul/nokhwa/blob/043d326583c1ea82e0e8f6f62a267cea954a751a/src/utils.rs#L1238-L1246