### PR TITLE
minimum and maximum inclusive, and a fix for the step validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ optional = true
 
 [dependencies.nokhwa-bindings-windows]
 version = "0.3.4"
+path = "nokhwa-bindings-windows"
 optional = true
 
 [dependencies.nokhwa-bindings-macos]

--- a/examples/setting/Cargo.toml
+++ b/examples/setting/Cargo.toml
@@ -14,4 +14,4 @@ no-default-features = true
 [dependencies.nokhwa]
 path = "../../../nokhwa"
 # EDIT THIS!
-features = ["input-v4l"]
+features = ["input-msmf"]

--- a/nokhwa-bindings-windows/src/lib.rs
+++ b/nokhwa-bindings-windows/src/lib.rs
@@ -361,7 +361,7 @@ impl MFControl {
 
 #[cfg(all(windows, not(feature = "docs-only")))]
 pub mod wmf {
-    #![windows_subsystem = "windows"]
+    //#![windows_subsystem = "windows"]
     use crate::{
         BindingError, MFCameraFormat, MFControl, MFFrameFormat, MFResolution,
         MediaFoundationControls, MediaFoundationDeviceDescriptor,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -888,8 +888,7 @@ impl Display for KnownCameraControlFlag {
 /// This struct tells you everything about a particular [`KnownCameraControls`]. <br>
 /// However, you should never need to instantiate this struct, since its usually generated for you by `nokhwa`.
 /// The only time you should be modifying this struct is when you need to set a value and pass it back to the camera.
-/// NOTE: Assume the values for `min` and `max` as **non-inclusive**!.
-/// E.g. if the [`CameraControl`] says `min` is 100, the minimum is actually 101.
+/// NOTE: Assume the values for `min` and `max` as inclusive. It's normal that a cam is on min or max whe powered on.
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct CameraControl {
     control: KnownCameraControls,
@@ -917,19 +916,20 @@ impl CameraControl {
         flag: KnownCameraControlFlag,
         active: bool,
     ) -> Result<Self, NokhwaError> {
-        if value >= maximum {
+        if value > maximum {
             return Err(NokhwaError::StructureError {
                 structure: "CameraControl".to_string(),
                 error: "Value too large".to_string(),
             });
         }
-        if value <= minimum {
+        if value < minimum {
             return Err(NokhwaError::StructureError {
                 structure: "CameraControl".to_string(),
                 error: "Value too low".to_string(),
             });
         }
-        if value % step != 0 {
+        // step=0 => div/0 => some cams have steps smaller than the win32 unit
+        if (step > 1) && (value % step != 0) {
             return Err(NokhwaError::StructureError {
                 structure: "CameraControl".to_string(),
                 error: "Not aligned with step".to_string(),
@@ -976,25 +976,20 @@ impl CameraControl {
     /// # Errors
     /// If the `value` is below `min`, above `max`, or is not divisible by `step`, this will error
     pub fn set_value(&mut self, value: i32) -> Result<(), NokhwaError> {
-        if value >= self.maximum_value() {
+        if value > self.maximum_value() {
             return Err(NokhwaError::StructureError {
                 structure: "CameraControl".to_string(),
                 error: "Value too large".to_string(),
             });
         }
-        if value <= self.minimum_value() {
+        if value < self.minimum_value() {
             return Err(NokhwaError::StructureError {
                 structure: "CameraControl".to_string(),
                 error: "Value too low".to_string(),
             });
         }
-        if value == self.minimum_value() || value == self.maximum_value() {
-            return Err(NokhwaError::StructureError {
-                structure: "CameraControl".to_string(),
-                error: "Values not inclusive".to_string(),
-            });
-        }
-        if value % self.step() != 0 {
+        // step=0 => div/0 => some cams have steps smaller than the win32 unit
+        if (self.step() > 1) && (value % self.step() != 0) {
             return Err(NokhwaError::StructureError {
                 structure: "CameraControl".to_string(),
                 error: "Not aligned with step".to_string(),
@@ -1009,19 +1004,20 @@ impl CameraControl {
     /// # Errors
     /// If the `value` is below `min`, above `max`, or is not divisible by `step`, this will error
     pub fn with_value(self, value: i32) -> Result<Self, NokhwaError> {
-        if value >= self.maximum_value() {
+        if value > self.maximum_value() {
             return Err(NokhwaError::StructureError {
                 structure: "CameraControl".to_string(),
                 error: "Value too large".to_string(),
             });
         }
-        if value <= self.minimum_value() {
+        if value < self.minimum_value() {
             return Err(NokhwaError::StructureError {
                 structure: "CameraControl".to_string(),
                 error: "Value too low".to_string(),
             });
         }
-        if value % self.step() != 0 {
+        // step=0 => div/0 => some cams have steps smaller than the win32 unit
+        if (self.step() > 1) && (value % self.step() != 0) {
             return Err(NokhwaError::StructureError {
                 structure: "CameraControl".to_string(),
                 error: "Not aligned with step".to_string(),


### PR DESCRIPTION
Here is the fix for the maximum, minimum and step values for the controls.
My PTZ starts exactly at the minimum values, so the controls were not available before this fix.
Another problem is the step value. The step on the PTZ is actually smaller than the reported by the Windows, so you can only get a value of zero. Then the division operation divides by zero, halting the software.