### PR TITLE
fix opencv backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,8 @@ optional = true
 
 [dependencies.opencv]
 version = "0.70"
+default-features = false
+features = ["videoio"]
 optional = true
 
 [dependencies.rgb]

--- a/nokhwa-core/src/types.rs
+++ b/nokhwa-core/src/types.rs
@@ -42,15 +42,15 @@ impl Display for RequestedFormatType {
 
 /// A request to the camera for a valid [`CameraFormat`]
 #[derive(Copy, Clone, Debug, Hash, Ord, PartialOrd, Eq, PartialEq)]
-pub struct RequestedFormat {
+pub struct RequestedFormat<'a> {
     requested_format: RequestedFormatType,
-    wanted_decoder: &'static [FrameFormat],
+    wanted_decoder: &'a [FrameFormat],
 }
 
-impl RequestedFormat {
+impl RequestedFormat<'_> {
     /// Creates a new [`RequestedFormat`] by using the [`RequstedFormatType`] and getting the [`FrameFormat`]
     /// constraints from a generic type.
-    pub fn new<Decoder: FormatDecoder>(requested: RequestedFormatType) -> RequestedFormat {
+    pub fn new<Decoder: FormatDecoder>(requested: RequestedFormatType) -> RequestedFormat<'static> {
         RequestedFormat {
             requested_format: requested,
             wanted_decoder: Decoder::FORMATS,
@@ -61,7 +61,7 @@ impl RequestedFormat {
     /// constraints from a statically allocated slice.
     pub fn with_formats(
         requested: RequestedFormatType,
-        decoder: &'static [FrameFormat],
+        decoder: &[FrameFormat],
     ) -> RequestedFormat {
         RequestedFormat {
             requested_format: requested,
@@ -192,7 +192,7 @@ impl RequestedFormat {
     }
 }
 
-impl Display for RequestedFormat {
+impl Display for RequestedFormat<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self)
     }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -74,10 +74,9 @@ impl Camera {
         backend: ApiBackend,
     ) -> Result<Self, NokhwaError> {
         let camera_format = CameraFormat::new_from(width, height, fourcc, fps);
-        let temp = vec![fourcc];
         Camera::with_backend(
             index,
-            RequestedFormat::with_formats(RequestedFormatType::Exact(camera_format), &temp),
+            RequestedFormat::with_formats(RequestedFormatType::Exact(camera_format), &[fourcc]),
             backend,
         )
     }


### PR DESCRIPTION
I have fixed all of the compilation errors but currently the buffer to image buffer conversion crashes i.e.

```rs
let frame = camera.frame().unwrap();
let decoded_frame = frame.decode_image::<RgbFormat>().unwrap(); // crashes at decode_image (no panic)
```

Is this the right way to convert `Buffer` to `image::ImageBuffer`?

I am able to get a usable `image::ImageBuffer` with the following code:

```rs
let resolution = cap.resolution();
let raw_frame = cap.frame_raw().unwrap();
let decoded_frame: ImageBuffer<Rgb<u8>, Vec<_>> = image::ImageBuffer::from_vec(
    resolution.width(),
    resolution.height(),
    raw_frame.to_vec(),
)
.unwrap();
```