### PR TITLE
chore: bring example up to date with code

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,32 @@
+# Based on https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+#
+# While our "example" application has the platform-specific code,
+# for simplicity we are compiling and testing everything on the Ubuntu environment only.
+# For multi-OS testing see the `cross.yml` workflow.
+
+on:
+  pull_request: {}
+    
+
+name: Compile all examples
+
+# We specify the examples individually since they might need a different environment
+jobs:
+  compile_example_threaded_capture:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Cargo Check 
+        run: |
+          cd examples/threaded-capture
+          cargo check

--- a/examples/threaded-capture/Cargo.toml
+++ b/examples/threaded-capture/Cargo.toml
@@ -14,4 +14,4 @@ default-features = false
 [dependencies.nokhwa]
 path = "../../../nokhwa"
 # EDIT THIS!
-features = ["input-v4l", "output-threaded"]
+features = ["input-avfoundation", "output-threaded"]

--- a/examples/threaded-capture/Cargo.toml
+++ b/examples/threaded-capture/Cargo.toml
@@ -14,4 +14,4 @@ default-features = false
 [dependencies.nokhwa]
 path = "../../../nokhwa"
 # EDIT THIS!
-features = ["input-avfoundation", "output-threaded"]
+features = ["input-native", "output-threaded"]

--- a/examples/threaded-capture/src/main.rs
+++ b/examples/threaded-capture/src/main.rs
@@ -15,6 +15,7 @@
  */
 
 use nokhwa::{
+    nokhwa_initialize,
     pixel_format::RgbAFormat,
     query,
     utils::{ApiBackend, FrameFormat, RequestedFormat, RequestedFormatType},
@@ -22,6 +23,10 @@ use nokhwa::{
 };
 
 fn main() {
+    // only needs to be run on OSX
+    nokhwa_initialize(|granted| {
+        println!("User said {}", granted);
+    });
     let cameras = query(ApiBackend::Auto).unwrap();
     cameras.iter().for_each(|cam| println!("{:?}", cam));
 

--- a/examples/threaded-capture/src/main.rs
+++ b/examples/threaded-capture/src/main.rs
@@ -16,9 +16,9 @@
 
 use nokhwa::{
     nokhwa_initialize,
-    pixel_format::RgbAFormat,
+    pixel_format::{RgbAFormat, RgbFormat},
     query,
-    utils::{ApiBackend, FrameFormat, RequestedFormat, RequestedFormatType},
+    utils::{ApiBackend, RequestedFormat, RequestedFormatType},
     CallbackCamera,
 };
 
@@ -30,10 +30,7 @@ fn main() {
     let cameras = query(ApiBackend::Auto).unwrap();
     cameras.iter().for_each(|cam| println!("{:?}", cam));
 
-    let format = RequestedFormat::with_formats(
-        RequestedFormatType::AbsoluteHighestFrameRate,
-        &[FrameFormat::GRAY],
-    );
+    let format = RequestedFormat::new::<RgbFormat>(RequestedFormatType::AbsoluteHighestFrameRate);
 
     let first_camera = cameras.first().unwrap();
 

--- a/nokhwa-bindings-macos/src/lib.rs
+++ b/nokhwa-bindings-macos/src/lib.rs
@@ -924,7 +924,6 @@ mod internal {
                             "Not Found".to_string(),
                         )),
                     }
-                    ƒ
                 }
                 CameraIndex::String(id) => Ok(AVCaptureDevice::from_id(id, None)?),
             }


### PR DESCRIPTION
Hey there, I made a quick PR to bring the threaded example in sync with the actual code. I also added a github action so it stays in sync, I hope that's okay :) 

When I run this I get

```
     Running `/Users/danielschmidt/fun/nokhwa/target/debug/threaded-capture`
CameraInfo { human_name: "FaceTime HD Camera", description: "Apple Inc.: FaceTime HD Camera - AVCaptureDeviceTypeBuiltInWideAngleCamera, Unspecified f0", misc: "EAB7A68F-EC2B-4487-AADF-D8A91C1CB782", index: Index(0) }
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: OpenDeviceError("0", "Not Found")', examples/threaded-capture/src/main.rs:39:6
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Is this expected in the current RC state?