### PR TITLE
fix compile error in threaded.rs

### DIFF
--- a/src/threaded.rs
+++ b/src/threaded.rs
@@ -100,6 +100,7 @@ impl CallbackCamera {
     ///
     /// You **must** have set a format beforehand.
     pub fn with_custom(camera: Camera, callback: impl FnMut(Buffer) + Send + 'static) -> Self {
+        let current_camera = camera.info().clone();
         CallbackCamera {
             camera: Arc::new(Mutex::new(camera)),
             frame_callback: Arc::new(Mutex::new(Box::new(callback))),


### PR DESCRIPTION
The current master/senpai doesn't compile because current_camera is used but not defined in a function in src/threaded.rs. This fixes it in the most obvious way.