### PR TITLE
Disable unnessesary ggez features

### DIFF
--- a/examples/capture/Cargo.toml
+++ b/examples/capture/Cargo.toml
@@ -9,10 +9,13 @@ edition = "2021"
 default = ["nokhwa/default"]
 
 [dependencies]
-ggez = "0.8.1"
 flume = "0.10.14"
 once_cell = "1.16.0"
 color-eyre = "0.6.2"
+
+[dependencies.ggez]
+version = "0.8.1"
+default-features = false
 
 [dependencies.clap]
 version = "4.0.20"


### PR DESCRIPTION
On aarch64-pc-windows-msvc I had some trouble compiling the capture example, because of some mp3 library (minimp3) used by ggez. Since nokhwa only uses the graphics parts of ggez it seems easiest to just disable all other features. This should also generally improve build speed of he example.