### PR TITLE
Fix spelling of AVCaptureDeviceTypeExternalUnknown

### DIFF
--- a/nokhwa-bindings-macos/src/lib.rs
+++ b/nokhwa-bindings-macos/src/lib.rs
@@ -570,7 +570,7 @@ mod internal {
                     str_to_nsstr("AVCaptureDeviceTypeBuiltInTrueDepthCamera")
                 }
                 AVCaptureDeviceType::ExternalUnknown => {
-                    str_to_nsstr("AVCaptureDeviceTypeBuiltInExternalUnknown")
+                    str_to_nsstr("AVCaptureDeviceTypeExternalUnknown")
                 }
             }
         }


### PR DESCRIPTION
The typo caused USB webcams to not be reported by the library. Perhaps the device types should reference the global variables instead of directly using the strings so that typos like this result in linker errors instead of silently failing to find certain categories of cameras? (I'd be willing to create a pull request)