### PR TITLE
Avoid deadlock on non-match in guid_to_frameformat.  Fix for #87.

### DIFF
--- a/nokhwa-bindings-windows/src/lib.rs
+++ b/nokhwa-bindings-windows/src/lib.rs
@@ -639,7 +639,10 @@ pub mod wmf {
 
                 let frame_fmt = match guid_to_frameformat(fourcc) {
                     Some(fcc) => fcc,
-                    None => continue,
+                    None => {
+                        index += 1;
+                        continue;
+                    },
                 };
 
                 for frame_rate in framerate_list {


### PR DESCRIPTION
Fix for issue #87 .

If guid_to_frameformat returns None, index is not updated and this spins.

Another solution might be to move index += 1 to the top of the method, which would be nice in that future 'continues' don't have to have the index += 1.  Index does not appear to be used elsewhere in the block so this should be okay.