### PR TITLE
Support Windows Hello IR sensors

### DIFF
--- a/nokhwa-core/src/pixel_format.rs
+++ b/nokhwa-core/src/pixel_format.rs
@@ -77,6 +77,7 @@ impl FormatDecoder for RgbFormat {
                 .collect()),
             FrameFormat::RAWRGB => Ok(data.to_vec()),
             FrameFormat::NV12 => nv12_to_rgb(resolution, data, false),
+            FrameFormat::L8 => panic!("Unsupported conversion from L8 to RGB"),
         }
     }
 
@@ -112,6 +113,7 @@ impl FormatDecoder for RgbFormat {
                 Ok(())
             }
             FrameFormat::NV12 => buf_nv12_to_rgb(resolution, data, dest, false),
+            FrameFormat::L8 => panic!("Unsupported conversion from L8 to RGB"),
         }
     }
 }
@@ -151,6 +153,7 @@ impl FormatDecoder for RgbAFormat {
                 .flat_map(|x| [x[0], x[1], x[2], 255])
                 .collect()),
             FrameFormat::NV12 => nv12_to_rgb(resolution, data, true),
+            FrameFormat::L8 => panic!("Unsupported conversion from L8 to RGBA"),
         }
     }
 
@@ -194,6 +197,7 @@ impl FormatDecoder for RgbAFormat {
                 Ok(())
             }
             FrameFormat::NV12 => buf_nv12_to_rgb(resolution, data, dest, true),
+            FrameFormat::L8 => panic!("Unsupported conversion from L8 to RGB"),
         }
     }
 }
@@ -253,6 +257,7 @@ impl FormatDecoder for LumaFormat {
                 .chunks(3)
                 .map(|px| ((i32::from(px[0]) + i32::from(px[1]) + i32::from(px[2])) / 3) as u8)
                 .collect()),
+            FrameFormat::L8 => Ok(data.to_vec()),
         }
     }
 
@@ -273,7 +278,7 @@ impl FormatDecoder for LumaFormat {
                 })
             }
 
-            FrameFormat::GRAY => {
+            FrameFormat::GRAY | FrameFormat::L8 => {
                 data.iter().zip(dest.iter_mut()).for_each(|(pxv, d)| {
                     *d = *pxv;
                 });
@@ -337,7 +342,7 @@ impl FormatDecoder for LumaAFormat {
                     [(avg / 3) as u8, 255]
                 })
                 .collect()),
-            FrameFormat::GRAY => Ok(data.iter().flat_map(|x| [*x, 255]).collect()),
+            FrameFormat::GRAY | FrameFormat::L8 => Ok(data.iter().flat_map(|x| [*x, 255]).collect()),
             FrameFormat::RAWRGB => Err(NokhwaError::ProcessFrameError {
                 src: fcc,
                 destination: "RGB => RGB".to_string(),
@@ -372,7 +377,7 @@ impl FormatDecoder for LumaAFormat {
                 destination: "NV12 => LumaA".to_string(),
                 error: "Conversion Error".to_string(),
             }),
-            FrameFormat::GRAY => {
+            FrameFormat::GRAY | FrameFormat::L8 => {
                 if dest.len() != data.len() * 2 {
                     return Err(NokhwaError::ProcessFrameError {
                         src: fcc,

--- a/nokhwa-core/src/traits.rs
+++ b/nokhwa-core/src/traits.rs
@@ -173,7 +173,7 @@ pub trait CaptureBackendTrait {
         let resolution = cfmt.resolution();
         let pxwidth = match cfmt.format() {
             FrameFormat::MJPEG | FrameFormat::YUYV | FrameFormat::RAWRGB | FrameFormat::NV12 => 3,
-            FrameFormat::GRAY => 1,
+            FrameFormat::GRAY | FrameFormat::L8 => 1,
         };
         if alpha {
             return (resolution.width() * resolution.height() * (pxwidth + 1)) as usize;

--- a/nokhwa-core/src/types.rs
+++ b/nokhwa-core/src/types.rs
@@ -299,6 +299,7 @@ pub enum FrameFormat {
     NV12,
     GRAY,
     RAWRGB,
+    L8,
 }
 
 impl Display for FrameFormat {
@@ -319,6 +320,7 @@ impl Display for FrameFormat {
             FrameFormat::NV12 => {
                 write!(f, "NV12")
             }
+            FrameFormat::L8 => write!(f, "L8"),
         }
     }
 }
@@ -332,6 +334,7 @@ impl FromStr for FrameFormat {
             "GRAY" => Ok(FrameFormat::GRAY),
             "RAWRGB" => Ok(FrameFormat::RAWRGB),
             "NV12" => Ok(FrameFormat::NV12),
+            "L8" => Ok(FrameFormat::L8),
             _ => Err(NokhwaError::StructureError {
                 structure: "FrameFormat".to_string(),
                 error: format!("No match for {s}"),
@@ -349,6 +352,7 @@ pub const fn frame_formats() -> &'static [FrameFormat] {
         FrameFormat::NV12,
         FrameFormat::GRAY,
         FrameFormat::RAWRGB,
+        FrameFormat::L8,
     ]
 }
 

--- a/src/backends/capture/msmf_backend.rs
+++ b/src/backends/capture/msmf_backend.rs
@@ -57,10 +57,10 @@ impl MediaFoundationCaptureDevice {
             index.clone(),
         );
 
-        let availible = mf_device.compatible_format_list()?;
+        let available = mf_device.compatible_format_list()?;
 
         let desired = camera_fmt
-            .fulfill(&availible)
+            .fulfill(&available)
             .ok_or(NokhwaError::InitializeError {
                 backend: ApiBackend::MediaFoundation,
                 error: "Failed to fulfill requested format".to_string(),


### PR DESCRIPTION
This PR adds support for reading from the Windows Hello IR sensors by:
1. Enumerating them in `query_activate_pointers`.
2. Adding support for `MF_VIDEO_FORMAT_L8`

This works on my machine, but I'm unsure if any other formats are used in practice.

I don't really like having added the `MF_VIDEO_FORMAT_L8` as a separate `FrameFormat` (because it's essentially the same as `GRAY`), but it's also unclear to me how to do this better without rewriting the way in which `fulfill` works.