### PR TITLE
Use fair mutex for CallbackCamera

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ input-opencv = ["opencv", "opencv/rgb", "rgb", "nokhwa-core/opencv-mat"]
 input-jscam = ["web-sys", "js-sys", "wasm-bindgen-futures", "wasm-bindgen", "wasm-rs-async-executor"]
 output-wgpu = ["wgpu", "nokhwa-core/wgpu-types"]
 #output-wasm = ["input-jscam"]
-output-threaded = []
+output-threaded = ["parking_lot"]
 small-wasm = []
-docs-only = ["input-native", "input-opencv", "input-jscam","output-wgpu", "output-threaded", "serialize"]
+docs-only = ["input-native", "input-opencv", "input-jscam", "output-wgpu", "output-threaded", "serialize"]
 docs-nolink = ["opencv/docs-only", "nokhwa-core/docs-features"]
 docs-features = []
 test-fail-warning = []
@@ -100,6 +100,10 @@ optional = true
 version = "1.7"
 optional = true
 
+[dependencies.parking_lot]
+version = "0.12"
+optional = true
+
 [dependencies.web-sys]
 version = "0.3"
 features = [
@@ -135,6 +139,9 @@ optional = true
 [dependencies.wasm-rs-async-executor]
 version = "0.9"
 optional = true
+
+[dev-dependencies]
+anyhow = "1.0.70"
 
 [package.metadata.docs.rs]
 features = ["docs-only", "docs-nolink", "docs-features"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,8 +140,5 @@ optional = true
 version = "0.9"
 optional = true
 
-[dev-dependencies]
-anyhow = "1.0.70"
-
 [package.metadata.docs.rs]
 features = ["docs-only", "docs-nolink", "docs-features"]


### PR DESCRIPTION
This fixes lock contention that prevented any operations on the camera once capture loop is started by using a fair mutex instead of a regular one.

It's slightly more expensive, but this usecase - trying to access a shared resource that is repeatedly locked/unlocked by someone else - is exactly what it's designed for, and indeed it fixes the deadlock issue.

Fixes #111.