### PR TITLE
Fix compile error caused by wgpu api changes

### DIFF
--- a/nokhwa-core/src/traits.rs
+++ b/nokhwa-core/src/traits.rs
@@ -193,7 +193,6 @@ pub trait CaptureBackendTrait {
         label: Option<&'a str>,
     ) -> Result<WgpuTexture, NokhwaError> {
         use crate::pixel_format::RgbAFormat;
-        use std::num::NonZeroU32;
         let frame = self.frame()?.decode_image::<RgbAFormat>()?;
 
         let texture_size = Extent3d {
@@ -213,15 +212,9 @@ pub trait CaptureBackendTrait {
             view_formats: &[],
         });
 
-        let width_nonzero = match NonZeroU32::try_from(4 * frame.width()) {
-            Ok(w) => Some(w),
-            Err(why) => return Err(NokhwaError::ReadFrameError(why.to_string())),
-        };
+        let width = 4 * frame.width();
 
-        let height_nonzero = match NonZeroU32::try_from(frame.height()) {
-            Ok(h) => Some(h),
-            Err(why) => return Err(NokhwaError::ReadFrameError(why.to_string())),
-        };
+        let height = frame.height();
 
         queue.write_texture(
             ImageCopyTexture {
@@ -233,8 +226,8 @@ pub trait CaptureBackendTrait {
             &frame,
             ImageDataLayout {
                 offset: 0,
-                bytes_per_row: width_nonzero,
-                rows_per_image: height_nonzero,
+                bytes_per_row: Some(width),
+                rows_per_image: Some(height),
             },
             texture_size,
         );


### PR DESCRIPTION
Due to https://github.com/gfx-rs/wgpu/pull/3529, some types have been changed. The dependencies were updated to `wgpu` 0.16, but the code wasn't updated.

I have no idea whether to check the `0` value now or not, so I just use frame size and pass it to `wgpu`.