### PR TITLE
Simplify workspace paths (0.10)

### DIFF
--- a/examples/capture/Cargo.toml
+++ b/examples/capture/Cargo.toml
@@ -20,7 +20,7 @@ features = ["derive"]
 
 # Use these as you need
 [dependencies.nokhwa]
-path = "../../../nokhwa"
+path = "../.."
 features = ["input-native", "output-threaded"]
 
 [dependencies.image]

--- a/examples/setting/Cargo.toml
+++ b/examples/setting/Cargo.toml
@@ -12,6 +12,6 @@ version = "0.23.14"
 default-features = false
 
 [dependencies.nokhwa]
-path = "../../../nokhwa"
+path = "../.."
 # EDIT THIS!
 features = ["input-v4l"]

--- a/examples/threaded-capture/Cargo.toml
+++ b/examples/threaded-capture/Cargo.toml
@@ -12,6 +12,6 @@ version = "0.23.14"
 default-features = false
 
 [dependencies.nokhwa]
-path = "../../../nokhwa"
+path = "../.."
 # EDIT THIS!
 features = ["input-native", "output-threaded"]


### PR DESCRIPTION
This PR simplifies the local dependencies' paths to stay within the project's hierarchy. This is required if the project was cloned in a local folder not named `nokhwa`. Otherwise, cargo cannot properly find the workspace's projects and fails (this was my case as I'm using Nix and [crane](https://github.com/ipetkov/crane) which fails to properly download and validate nokhwa due to this).

I don't know if 0.10 is still maintain. I'm just pushing this here as I'm still using 0.10. #120 is the same but for the `senpai` branch.