### PR TITLE
Add Raspberry Pi support

### DIFF
--- a/examples/capture/Cargo.toml
+++ b/examples/capture/Cargo.toml
@@ -20,7 +20,7 @@ features = ["derive"]
 
 # Use these as you need
 [dependencies.nokhwa]
-path = "../../../nokhwa"
+path = "../.."
 features = ["input-native", "output-threaded"]
 
 [dependencies.image]

--- a/examples/setting/Cargo.toml
+++ b/examples/setting/Cargo.toml
@@ -12,6 +12,6 @@ version = "0.23.14"
 default-features = false
 
 [dependencies.nokhwa]
-path = "../../../nokhwa"
+path = "../.."
 # EDIT THIS!
 features = ["input-v4l"]

--- a/examples/threaded-capture/Cargo.toml
+++ b/examples/threaded-capture/Cargo.toml
@@ -12,6 +12,6 @@ version = "0.23.14"
 default-features = false
 
 [dependencies.nokhwa]
-path = "../../../nokhwa"
+path = "../.."
 # EDIT THIS!
 features = ["input-native", "output-threaded"]


### PR DESCRIPTION
This PR fixes the "Failed to fulfill" issue on the Raspberry Pi 3 with a Raspberry Pi camera.

It does so by:

- Including the max frame interval step which was dropped in the previous version. The Raspberry Pi camera has multiple steps, but a single numerator value `1` which was dropped because of this. On its own, this should fix the "Failed to fulfill" issue.
- Explicitly starting the capture stream (Raspberry Pi only). While `v4l` does that automatically on its own on the first capture, it also queues several buffers for the camera. Those buffers end up not being released properly by the Raspberry Pi V4L2 driver which chokes and crashes the camera. By starting the capture explicitly, `v4l` allocates a single buffer which is properly managed and doesn't crashes the camera.

Should hopefully fix some other "Failed to fulfill" issues as well. It should at least fix the one encountered on Raspberry PI (#99) which looked like mine.