### PR TITLE
🐛 v4l: fix perf issue introduce by disabled arena buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,11 @@ decoding = ["nokhwa-core/mjpeg"]
 input-avfoundation = ["nokhwa-bindings-macos"]
 input-msmf = ["nokhwa-bindings-windows"]
 input-v4l = ["nokhwa-bindings-linux"]
+# Disable arena buffer on v4l
+# This should fix crash on Raspberry Pi that have faulty v4l driver.
+# WARNING: This create a performance regression, half of the frames will be dropped
+# You shouldn't enable this unless you have to.
+input-v4l-no-arena-buffer = ["nokhwa-bindings-linux/no-arena-buffer"]
 input-native = ["input-avfoundation", "input-v4l", "input-msmf"]
 # Re-enable it once soundness has been proven + mozjpeg is updated to 0.9.x
 # input-uvc = ["uvc", "uvc/vendor", "usb_enumeration", "lazy_static"]

--- a/nokhwa-bindings-linux/Cargo.toml
+++ b/nokhwa-bindings-linux/Cargo.toml
@@ -8,6 +8,11 @@ description = "The V4L2 bindings crate for `nokhwa`"
 keywords = ["v4l", "v4l2", "linux", "capture", "webcam"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Disable arena buffer of v4l2 for the crate to work on raspberry pi with faulty v4l2 driver
+# https://github.com/l1npengtul/nokhwa/pull/121
+no-arena-buffer = []
+
 [dependencies]
 
 [dependencies.nokhwa-core]

--- a/nokhwa-bindings-linux/src/lib.rs
+++ b/nokhwa-bindings-linux/src/lib.rs
@@ -853,12 +853,17 @@ mod internal {
         }
 
         fn open_stream(&mut self) -> Result<(), NokhwaError> {
+            // Disable mut warning, since mut is only required when not using arena buffers
+            #[allow(unused_mut)]
             let mut stream =
                 match MmapStream::new(&*self.lock_device()?, v4l::buffer::Type::VideoCapture) {
                     Ok(s) => s,
                     Err(why) => return Err(NokhwaError::OpenStreamError(why.to_string())),
                 };
+
             // Explicitly start now, or won't work with the RPi. As a consequence, buffers will only be used as required.
+            // WARNING: This will cause drop of half of the frames
+            #[cfg(feature = "no-arena-buffer")]
             match stream.start() {
                 Ok(s) => s,
                 Err(why) => return Err(NokhwaError::OpenStreamError(why.to_string())),


### PR DESCRIPTION
fix #128 

- Calling `stream.next` push internal buffers to v4l then call `stream.start`. By default with `new` buffer count is 4.
- #121 directly call `stream.start`, without setting any buffer. This result in v4l only having 1 buffer (I guess), so because there is no double buffer (or more), 1 frame out of two is skipped.

I used the following python script to benchmark expected camera behavior:
```python
import cv2


# Create a VideoCapture object
cap = cv2.VideoCapture(0)

# Check if camera opened successfully
if cap.isOpened() == False:
    print("Unable to read camera feed")

# Define the codec and create VideoWriter object.The output is stored in 'outpy.avi' file.
window_name = "Image"
cv2.namedWindow(window_name, cv2.WINDOW_NORMAL)

fps_count = 0
last_fps_time_updated = 0

while True:
    ret, frame = cap.read()

    # print frame.shape
    print(f"Frame: {frame.shape}")

    if ret == True:
        # Display the resulting frame
        cv2.imshow(window_name, frame)

        fps_count += 1
        current_time = cv2.getTickCount()
        if (current_time - last_fps_time_updated) > cv2.getTickFrequency():
            print("FPS: {}".format(fps_count))
            fps_count = 0
            last_fps_time_updated = current_time

        # Press Q on keyboard to stop recording
        if cv2.waitKey(1) & 0xFF == ord("q"):
            break

    # Break the loop
    else:
        break
```

And the following rust code:
```rust
                let mut camera = Camera::new(
                    index.clone(),
                    RequestedFormat::new::<RgbFormat>(RequestedFormatType::Closest(
                        CameraFormat::new(
                            Resolution {
                                width_x: 320,
                                height_y: 240,
                            },
                            FrameFormat::MJPEG,
                            30,
                        ),
                    )),
                )
                .unwrap();

                println!("format = {:?}", camera.camera_format());
                let mut last_fps_updated = std::time::Instant::now();
                let mut frame_count = 0;
                camera.open_stream().unwrap();
                loop {
                    let frame = camera.frame().unwrap();
                    println!(
                        "Captured frame of size {}, with size {:?}, format {:?}",
                        frame.buffer().len(),
                        frame.resolution(),
                        frame.source_frame_format()
                    );
                    let decoded = frame.decode_image::<RgbFormat>().unwrap();
                    println!(
                        "DecodedFrame of {}, resolution {:?}x{:?}",
                        decoded.len(),
                        decoded.width(),
                        decoded.height()
                    );
                    frame_count += 1;

                    let now = std::time::Instant::now();
                    if now - last_fps_updated > std::time::Duration::from_secs(1) {
                        println!("FPS: {}", frame_count);

                        frame_count = 0;
                        last_fps_updated = now;
                    }
                }
```

The performance regression can easily be observed in v4l examples too by adding `stream.start`:

https://github.com/raymanfx/libv4l-rs/blob/867d9b122fde603ff7f1bfcdf19de48845c9e1f7/examples/stream_capture_mmap.rs#L26-L29