### PR TITLE
Fix cross compilation on a macos host

### DIFF
--- a/nokhwa-bindings-macos/build.rs
+++ b/nokhwa-bindings-macos/build.rs
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 fn main() {
-    println!("cargo:rustc-link-lib=framework=CoreMedia");
-    println!("cargo:rustc-link-lib=framework=AVFoundation");
-    println!("cargo:rustc-link-lib=framework=CoreVideo");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os == "macos" || target_os == "ios" {
+        println!("cargo:rustc-link-lib=framework=CoreMedia");
+        println!("cargo:rustc-link-lib=framework=AVFoundation");
+        println!("cargo:rustc-link-lib=framework=CoreVideo");
+    }
 }
-
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
-fn main() {}


### PR DESCRIPTION
In a build script `#[cfg(target_os=...)]` refers to the host, not the target. Using the `CARGO_CFG_TARGET_OS` environment variable sets the link parameters properly.