### PR TITLE
Reuse OpenCV matrix (decode_into_opencv_mat)

### DIFF
--- a/nokhwa-core/src/buffer.rs
+++ b/nokhwa-core/src/buffer.rs
@@ -206,11 +206,13 @@ impl Buffer {
                 });
             }
 
-            if dst.typ() != array_type {
+            if dst.rows() != self.resolution.height_y as _
+                || dst.cols() != self.resolution.width_x as _
+            {
                 return Err(NokhwaError::ProcessFrameError {
                     src: FrameFormat::RAWRGB,
                     destination: "OpenCV Mat".to_string(),
-                    error: "Invalid Matrix Channel Count".to_string(),
+                    error: "Invalid Matrix Dimensions".to_string(),
                 });
             }
         }

--- a/nokhwa-core/src/buffer.rs
+++ b/nokhwa-core/src/buffer.rs
@@ -118,21 +118,46 @@ impl Buffer {
     pub fn decode_opencv_mat<F: FormatDecoder>(
         &mut self,
     ) -> Result<opencv::core::Mat, NokhwaError> {
-        use opencv::core::Mat;
-        let mut mat = Mat::default();
-        self.decode_into_opencv_mat::<F>(&mut mat)?;
-        Ok(mat)
+        use image::Pixel;
+        use opencv::core::{Mat, Mat_AUTO_STEP, CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4};
+
+        let array_type = match F::Output::CHANNEL_COUNT {
+            1 => CV_8UC1,
+            2 => CV_8UC2,
+            3 => CV_8UC3,
+            4 => CV_8UC4,
+            _ => {
+                return Err(NokhwaError::ProcessFrameError {
+                    src: FrameFormat::RAWRGB,
+                    destination: "OpenCV Mat".to_string(),
+                    error: "Invalid Decoder FormatDecoder Channel Count".to_string(),
+                })
+            }
+        };
+
+        unsafe {
+            // TODO: Look into removing this unnecessary copy.
+            let mat1 = Mat::new_rows_cols_with_data(
+                self.resolution.height_y as i32,
+                self.resolution.width_x as i32,
+                array_type,
+                self.buffer.as_ref().as_ptr().cast_mut().cast(),
+                Mat_AUTO_STEP,
+            )
+            .map_err(|why| NokhwaError::ProcessFrameError {
+                src: FrameFormat::RAWRGB,
+                destination: "OpenCV Mat".to_string(),
+                error: why.to_string(),
+            })?;
+
+            Ok(mat1)
+        }
     }
 
     /// Decodes a image with allocation using the provided [`FormatDecoder`] into a [`Mat`](https://docs.rs/opencv/latest/opencv/core/struct.Mat.html).
     ///
-    /// Note that this does a clone when creating the buffer, to decouple the lifetime of the internal data to the temporary Buffer. If you want to avoid this, please see [`decode_opencv_mat`](Self::decode_opencv_mat).
     /// # Errors
     /// Will error when the decoding fails, or `OpenCV` failed to create/copy the [`Mat`](https://docs.rs/opencv/latest/opencv/core/struct.Mat.html).
-    /// # Safety
-    /// This function uses `unsafe` in order to create the [`Mat`](https://docs.rs/opencv/latest/opencv/core/struct.Mat.html). Please see [`Mat::new_rows_cols_with_data`](https://docs.rs/opencv/latest/opencv/core/struct.Mat.html#method.new_rows_cols_with_data) for more.
-    ///
-    /// Most notably, the `data` **must** stay in scope for the duration of the [`Mat`](https://docs.rs/opencv/latest/opencv/core/struct.Mat.html) or bad, ***bad*** things happen.
     #[cfg(feature = "opencv-mat")]
     #[cfg_attr(feature = "docs-features", doc(cfg(feature = "opencv-mat")))]
     #[allow(clippy::cast_possible_wrap)]
@@ -142,7 +167,7 @@ impl Buffer {
     ) -> Result<(), NokhwaError> {
         use image::Pixel;
         use opencv::core::{
-            Mat, MatTraitConst, MatTraitManual, Mat_AUTO_STEP, CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4,
+            Mat, MatTraitConst, MatTraitManual, Scalar, CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4,
         };
 
         let array_type = match F::Output::CHANNEL_COUNT {
@@ -159,24 +184,20 @@ impl Buffer {
             }
         };
 
-        // If destination is no_array(), create a new matrix.
+        // If destination does not exist, create a new matrix.
         if dst.empty() {
-            *dst = unsafe {
-                Mat::new_rows_cols_with_data(
-                    self.resolution.height_y as i32,
-                    self.resolution.width_x as i32,
-                    array_type,
-                    self.buffer.as_ref().as_ptr().cast_mut().cast(),
-                    Mat_AUTO_STEP,
-                )
-                .map_err(|why| NokhwaError::ProcessFrameError {
-                    src: FrameFormat::RAWRGB,
-                    destination: "OpenCV Mat".to_string(),
-                    error: why.to_string(),
-                })?
-            };
+            *dst = Mat::new_rows_cols_with_default(
+                self.resolution.height_y as i32,
+                self.resolution.width_x as i32,
+                array_type,
+                Scalar::default(),
+            )
+            .map_err(|why| NokhwaError::ProcessFrameError {
+                src: FrameFormat::RAWRGB,
+                destination: "OpenCV Mat".to_string(),
+                error: why.to_string(),
+            })?;
         } else {
-            // ..
             if dst.typ() != array_type {
                 return Err(NokhwaError::ProcessFrameError {
                     src: FrameFormat::RAWRGB,
@@ -192,29 +213,29 @@ impl Buffer {
                     error: "Invalid Matrix Channel Count".to_string(),
                 });
             }
-
-            let mut bytes = match dst.data_bytes_mut() {
-                Ok(bytes) => bytes,
-                Err(_e) => {
-                    return Err(NokhwaError::ProcessFrameError {
-                        src: FrameFormat::RAWRGB,
-                        destination: "OpenCV Mat".to_string(),
-                        error: "Matrix Must Be Continuous".to_string(),
-                    })
-                }
-            };
-
-            let mut buffer = self.buffer.as_ref();
-            if bytes.len() != buffer.len() {
-                return Err(NokhwaError::ProcessFrameError {
-                    src: FrameFormat::RAWRGB,
-                    destination: "OpenCV Mat".to_string(),
-                    error: "Matrix Buffer Size Mismatch".to_string(),
-                });
-            }
-
-            buffer.copy_to_slice(&mut bytes);
         }
+
+        let mut bytes = match dst.data_bytes_mut() {
+            Ok(bytes) => bytes,
+            Err(_e) => {
+                return Err(NokhwaError::ProcessFrameError {
+                    src: FrameFormat::RAWRGB,
+                    destination: "OpenCV Mat".to_string(),
+                    error: "Matrix Must Be Continuous".to_string(),
+                })
+            }
+        };
+
+        let mut buffer = self.buffer.as_ref();
+        if bytes.len() != buffer.len() {
+            return Err(NokhwaError::ProcessFrameError {
+                src: FrameFormat::RAWRGB,
+                destination: "OpenCV Mat".to_string(),
+                error: "Matrix Buffer Size Mismatch".to_string(),
+            });
+        }
+
+        buffer.copy_to_slice(&mut bytes);
 
         Ok(())
     }


### PR DESCRIPTION
Hi! I came across `decode_opencv_mat` and figured it might be useful to have a function that decodes into an existing matrix.

I sketched out the idea against the `0.10` branch (I failed to get `senpai` to work) with `decode_into_opencv_mat`. This function takes a mutable destination matrix, and either creates a new matrix if the destination was zero-sized or copies the decoded bytes to the existing buffer.

This behavior is different from `decode_opencv_mat` in that the original buffer is not shared between the decoded image and the `Mat`.

Now caveat emptor: I could not test it thoroughly because I'm getting a ton of OpenCV build errors, but you might have a working test suite?