### PR TITLE
Type fix to ImageDataLayout construction under the wgu-types feature in nokhwa-core

### DIFF
--- a/nokhwa-core/src/traits.rs
+++ b/nokhwa-core/src/traits.rs
@@ -227,8 +227,8 @@ pub trait CaptureBackendTrait {
             &frame,
             ImageDataLayout {
                 offset: 0,
-                bytes_per_row: width_nonzero,
-                rows_per_image: height_nonzero,
+                bytes_per_row: Some(width_nonzero),
+                rows_per_image: Some(height_nonzero),
             },
             texture_size,
         );


### PR DESCRIPTION
`nokhwa-core` is unable compile when using the `--feature wgpu-types` flag due to a type mismatch.
This is referenced in issue #141, but I believe affects any system using this feature under the latest 0.10.3.

