### PR TITLE
avfoundation: set videoSettings explicitly

### DIFF
--- a/nokhwa-bindings-macos/Cargo.toml
+++ b/nokhwa-bindings-macos/Cargo.toml
@@ -19,6 +19,7 @@ path = "../nokhwa-core"
 core-media-sys = "0.1"
 core-video-sys = "0.1"
 cocoa-foundation = "0.1"
+core-foundation = "0.9.3"
 objc = { version = "0.2", features = ["exception"] }
 block = "0.1"
 flume = "0.10"

--- a/src/backends/capture/avfoundation.rs
+++ b/src/backends/capture/avfoundation.rs
@@ -252,6 +252,7 @@ impl CaptureBackendTrait for AVFoundationCaptureDevice {
         let videocallback = AVCaptureVideoCallback::new(bufname, &self.fbufsnd)?;
         let output = AVCaptureVideoDataOutput::new();
         output.add_delegate(&videocallback)?;
+        output.set_frame_format(self.camera_format().format())?;
         session.add_output(&output)?;
         session.commit_configuration();
         session.start()?;


### PR DESCRIPTION
It seems by default AVCaptureVideoDataOutput converts frames to kCMVideoCodecType_422YpCbCr8. (= kCMPixelFormat_422YpCbCr8) Unfortunately it doesn't match what nokhwa decides to use on my environment. (kCMPixelFormat_422YpCbCr8_yuvs)

This commit configures AVCaptureVideoDataOutput to use the same pixel format. (Thus no conversions)

Only tested for kCMPixelFormat_422YpCbCr8_yuvs.