### PR TITLE
Add AVCaptureDeviceType::External enum value to fix detecting external cameras (fixes #155)

### DIFF
--- a/nokhwa-bindings-macos/src/lib.rs
+++ b/nokhwa-bindings-macos/src/lib.rs
@@ -515,6 +515,7 @@ mod internal {
             AVCaptureDeviceType::Telephoto,
             AVCaptureDeviceType::TrueDepth,
             AVCaptureDeviceType::ExternalUnknown,
+            AVCaptureDeviceType::External
         ])?
         .devices())
     }
@@ -545,6 +546,7 @@ mod internal {
         Telephoto,
         TrueDepth,
         ExternalUnknown,
+        External
     }
 
     impl From<AVCaptureDeviceType> for *mut Object {
@@ -572,6 +574,7 @@ mod internal {
                 AVCaptureDeviceType::ExternalUnknown => {
                     str_to_nsstr("AVCaptureDeviceTypeExternalUnknown")
                 }
+                AVCaptureDeviceType::External => str_to_nsstr("AVCaptureDeviceTypeExternal"),
             }
         }
     }
@@ -814,6 +817,7 @@ mod internal {
                 AVCaptureDeviceType::Dual,
                 AVCaptureDeviceType::DualWide,
                 AVCaptureDeviceType::Triple,
+                AVCaptureDeviceType::External
             ])
         }
 


### PR DESCRIPTION
Uses the AVCaptureDeviceTypeExternal enum instead of AVCaptureDeviceTypeExternalUnknown which was deprecated.

See: https://developer.apple.com/documentation/avfoundation/avcapturedevicetypeexternalunknown