### PR TITLE
⬆️ Bump mozjpeg version to 0.10

### DIFF
--- a/nokhwa-core/Cargo.toml
+++ b/nokhwa-core/Cargo.toml
@@ -44,7 +44,7 @@ default-features = false
 optional = true
 
 [dependencies.mozjpeg]
-version = "0.9"
+version = "0.10"
 optional = true
 
 [dependencies.async-trait]


### PR DESCRIPTION
0.9 does not work anymore as mozjpeg-sys 1.* were deleted from crates.io