### PR TITLE
bump wgpu dependency to 23.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ version = "0.2"
 optional = true
 
 [dependencies.wgpu]
-version = "22"
+version = "23"
 optional = true
 
 [dependencies.opencv]


### PR DESCRIPTION
Currently, you use two versions of wgpu (22.0 and 23.0), causing this issue:
```
error[E0308]: arguments to this method are incorrect
    --> src/camera.rs:415:21
     |
415  |         self.device.frame_texture(device, queue, label)
     |                     ^^^^^^^^^^^^^ ------  ----- expected `wgpu::api::queue::Queue`, found `wgpu::Queue`
     |                                   |
     |                                   expected `wgpu::api::device::Device`, found `wgpu::Device`
```
This PR bumps the 22.0 to 23.0, fixing the error.

I don't completely understand the project structure so I could be wrong here, but using workspace dependencies might be good in this case to make sure all the dependencies are synchronized. I appreciate the work that you've put into this library :-) 