### PR TITLE
macOS: use YUYV for certain pixel types

### DIFF
--- a/nokhwa-bindings-macos/src/lib.rs
+++ b/nokhwa-bindings-macos/src/lib.rs
@@ -222,6 +222,7 @@ mod internal {
     use core_video_sys::{
         kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
         kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+        kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
     };
     use flume::{Receiver, Sender};
     use nokhwa_core::{
@@ -371,7 +372,7 @@ mod internal {
             kCMPixelFormat_8IndexedGray_WhiteIsZero => Some(FrameFormat::GRAY),
             kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
             | kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
-            | 875704438 => Some(FrameFormat::NV12),
+            | kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange => Some(FrameFormat::YUYV),
             kCMPixelFormat_24RGB => Some(FrameFormat::RAWRGB),
             _ => None,
         }


### PR DESCRIPTION
On macOS, use YUYV for the following pixel types:

- `kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange`
- `kCVPixelFormatType_420YpCbCr8BiPlanarFullRange`
- `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange`

Fixes #100, at least for me (M1 Macbook Pro).

This was suggested by the work of @paviro at
https://github.com/l1npengtul/nokhwa/issues/100#issuecomment-2217577611. (Thanks!)

@l1npengtul this is a small patch on the 0.10 branch. Any chance you could merge it and make a quick 0.10.6 release in the meantime before 0.11 arrives? I have been testing this for a couple months on macOS and it has been working fine for me. Thanks for this useful crate!