### PR TITLE
Short circuit when no devices found on Windows to fix panic in from_raw_parts

### DIFF
--- a/nokhwa-bindings-windows/src/lib.rs
+++ b/nokhwa-bindings-windows/src/lib.rs
@@ -264,6 +264,9 @@ pub mod wmf {
         }
 
         let mut device_list = vec![];
+        if count == 0 {
+            return Ok(device_list);
+        }
 
         unsafe { from_raw_parts(unused_mf_activate.assume_init(), count as usize) }
             .iter()


### PR DESCRIPTION
Fixes #205 and #192 on the 0.10 branch.