### PR TITLE
add open_stream to example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ let requested = RequestedFormat::new::<RgbFormat>(RequestedFormatType::AbsoluteH
 // make the camera
 let mut camera = Camera::new(index, requested).unwrap();
 
+// open stream so we can grab frames
+camera.open_stream().unwrap();
+
 // get a frame
 let frame = camera.frame().unwrap();
 println!("Captured Single Frame of {}", frame.buffer().len());


### PR DESCRIPTION
Adds `open_stream` to the example in the readme. I spent more time than I would have wanted to figure that out.
Unsure if this is a mistake, or on purpose :)