### PR TITLE
Fix duplicate index assertion in new_shared_device

### DIFF
--- a/nokhwa-bindings-linux/src/lib.rs
+++ b/nokhwa-bindings-linux/src/lib.rs
@@ -190,11 +190,9 @@ mod internal {
         // Last check to be sure that every devices have a unique index
         // and that the data isn't corrupted
         if devices.len() > 1 {
+            let indices: std::collections::HashSet<_> = devices.iter().map(|d| d.index).collect();
             assert_eq!(
-                devices
-                    .windows(2)
-                    .filter(|window| window[0].index == window[1].index)
-                    .count(),
+                indices.len(),
                 devices.len(),
                 "Device list should not contain duplicate indexes"
             );


### PR DESCRIPTION
Replace broken windows(2) logic with HashSet-based duplicate check. The previous assertion would always fail when 2+ devices with different indexes were opened sequentially.

Solves https://github.com/l1npengtul/nokhwa/issues/218