### PR TITLE
Fix mip_level bug in frame_texture causing crash

### DIFF
--- a/nokhwa-core/src/traits.rs
+++ b/nokhwa-core/src/traits.rs
@@ -225,7 +225,7 @@ pub trait CaptureBackendTrait {
         queue.write_texture(
             TexelCopyTextureInfoBase {
                 texture: &texture,
-                mip_level: 1,
+                mip_level: 0,
                 origin: Origin3d { x: 0, y: 0, z: 0 },
                 aspect: TextureAspect::All,
             },


### PR DESCRIPTION
## Problem
The `frame_texture` method in nokhwa-core 0.1.8 crashes with a wgpu validation error:
```
Unable to select texture mip level 1 out of 1
```

## Root Cause
In `nokhwa-core/src/traits.rs` line 228, the code writes to `mip_level: 1` but the texture is created with `mip_level_count: 1` (line 213), meaning only mip level 0 exists.

## Fix
Changed `mip_level: 1` to `mip_level: 0` to match the texture descriptor.

## Impact
This is a one-line fix for a crash that affects anyone using the `output-wgpu` feature with `frame_texture` method in the 0.10.x release.

Tested on macOS with wgpu 27.0.1.