### PR TITLE
fix(linux): accept V4L2 fourcc GREY for 8-bit grayscale

### DIFF
--- a/nokhwa-bindings-linux/src/lib.rs
+++ b/nokhwa-bindings-linux/src/lib.rs
@@ -920,7 +920,7 @@ mod internal {
         match fourcc.str().ok()? {
             "YUYV" => Some(FrameFormat::YUYV),
             "MJPG" => Some(FrameFormat::MJPEG),
-            "GRAY" => Some(FrameFormat::GRAY),
+            "GRAY" | "GREY" => Some(FrameFormat::GRAY),
             "RGB3" => Some(FrameFormat::RAWRGB),
             "BGR3" => Some(FrameFormat::RAWBGR),
             "NV12" => Some(FrameFormat::NV12),


### PR DESCRIPTION
The V4L2 standard fourcc for 8-bit greyscale is GREY (defined as V4L2_PIX_FMT_GREY in videodev2.h), but fourcc_to_frameformat only matches GRAY. This causes Camera::new to fail with GetPropertyError { property: "CameraFormat", error: "Failed to Fufill" } on any grayscale-only V4L2 device (e.g. IR cameras) because the reported format gets silently discarded by the _ => None fallthrough, resulting in an empty compatible formats list.
This patch accepts both GRAY and GREY in the parser.
Tested on an HP IR Camera (/dev/video2, reports GREY 640x360@15fps) which previously failed to open but now works correctly.