### PR TITLE
v4l: get_device_format: Do not fail on devices with exotic numerator

### DIFF
--- a/nokhwa-bindings-linux/src/lib.rs
+++ b/nokhwa-bindings-linux/src/lib.rs
@@ -213,7 +213,7 @@ mod internal {
                 let fps = match device.params() {
                     Ok(params) => {
                         if params.interval.numerator != 1
-                            || params.interval.denominator % params.interval.numerator != 0
+                            && params.interval.denominator % params.interval.numerator != 0
                         {
                             return Err(NokhwaError::GetPropertyError {
                                 property: "V4L2 FrameRate".to_string(),


### PR DESCRIPTION
On Asahi Linux, get_device_format currently fails because `params.interval.numerator` is 256 instead of 1. This causes the check to fail early even though the frame rate is a whole number. The second check `params.interval.denominator % params.interval.numerator != 0` would yield true but is currently never reached.

Change the condition from `or` to `and` so that v4l devices reporting a numerator > 1 still fail if framerate is not a whole number but succeed if it is.

Output of `v4l2-ctl --all`
```
Driver Info:
        Driver name      : apple-isp
        Card type        : FaceTime HD Camera
        Bus info         : platform:384000000.isp
        Driver version   : 6.19.14
        Capabilities     : 0x84200001
                Video Capture
                Streaming
                Extended Pix Format
                Device Capabilities
        Device Caps      : 0x04200001
                Video Capture
                Streaming
                Extended Pix Format
Priority: 2
Video input : 0 (apple-isp: ok)
Format Video Capture:
        Width/Height      : 1920/1080
        Pixel Format      : 'NV12' (Y/UV 4:2:0)
        Field             : None
        Bytes per Line    : 1920
        Size Image        : 3110400
        Colorspace        : Rec. 709
        Transfer Function : Rec. 709
        YCbCr/HSV Encoding: Rec. 709
        Quantization      : Default (maps to Limited Range)
        Flags             : 
Streaming Parameters Video Capture:
        Capabilities     : timeperframe
        Frames per second: 30.000 (7680/256)
        Read buffers     : 2
```