### PR TITLE
fix(macos): select format and frame-rate range from the same AVCaptureDeviceFormat

### DIFF
--- a/nokhwa-bindings-macos/src/lib.rs
+++ b/nokhwa-bindings-macos/src/lib.rs
@@ -990,7 +990,7 @@ mod internal {
             }
         }
 
-        pub fn lock(&self) -> Result<(), NokhwaError> {
+        pub fn lock(&mut self) -> Result<(), NokhwaError> {
             if self.locked {
                 return Ok(());
             }
@@ -1017,6 +1017,7 @@ mod internal {
                     error: "Lock Rejected".to_string(),
                 });
             }
+            self.locked = true;
             Ok(())
         }
 
@@ -1038,7 +1039,16 @@ mod internal {
             let mut selected_format: *mut Object = std::ptr::null_mut();
             let mut selected_range: *mut Object = std::ptr::null_mut();
 
-            for format in format_list {
+            // The format and frame-rate range must come from the SAME
+            // AVCaptureDeviceFormat: applying a range from another format
+            // throws NSInvalidArgumentException (and aborts through the
+            // objc catch). Devices commonly expose several formats with the
+            // same resolution (e.g. 420v and MJPEG), so pick both together
+            // and keep a consistent fallback.
+            let mut fallback_format: *mut Object = std::ptr::null_mut();
+            let mut fallback_range: *mut Object = std::ptr::null_mut();
+
+            'formats: for format in format_list {
                 let format_desc_ref: CMFormatDescriptionRef =
                     unsafe { msg_send![format.internal, performSelector: format_description_sel] };
                 let dimensions = unsafe { CMVideoFormatDescriptionGetDimensions(format_desc_ref) };
@@ -1046,19 +1056,29 @@ mod internal {
                 if dimensions.height == descriptor.resolution().height() as i32
                     && dimensions.width == descriptor.resolution().width() as i32
                 {
-                    selected_format = format.internal;
-
-                    for range in ns_arr_to_vec::<AVFrameRateRange>(unsafe {
+                    let ranges = ns_arr_to_vec::<AVFrameRateRange>(unsafe {
                         msg_send![format.internal, videoSupportedFrameRateRanges]
-                    }) {
+                    });
+                    if fallback_format.is_null() {
+                        if let Some(range) = ranges.first() {
+                            fallback_format = format.internal;
+                            fallback_range = range.inner;
+                        }
+                    }
+                    for range in &ranges {
                         let max_fps: f64 = unsafe { msg_send![range.inner, maxFrameRate] };
                         // Older Apple cameras (i.e. iMac 2013) return 29.97000002997 as FPS.
                         if (f64::from(descriptor.frame_rate()) - max_fps).abs() < 0.999 {
+                            selected_format = format.internal;
                             selected_range = range.inner;
-                            break;
+                            break 'formats;
                         }
                     }
                 }
+            }
+            if selected_format.is_null() || selected_range.is_null() {
+                selected_format = fallback_format;
+                selected_range = fallback_range;
             }
             if selected_range.is_null() || selected_format.is_null() {
                 return Err(NokhwaError::SetPropertyError {


### PR DESCRIPTION
Fixes #247.

## Problem

`AVCaptureDevice::set_all` overwrites `selected_format` for every format matching the requested resolution, while `selected_range` may come from an earlier format. Applying a frame-rate range that does not belong to the new `activeFormat` makes AVFoundation throw `NSInvalidArgumentException`, which cannot unwind through the `objc` catch and **aborts the process** instead of returning `Err`. Cameras exposing several formats at one resolution (e.g. Logitech UVC devices: 420v + MJPEG variants) hit this deterministically in `Camera::new()`.

## Change

- Pick `selected_format` and `selected_range` together from the same `AVCaptureDeviceFormat`, breaking at the first pair that satisfies the requested fps (keeping the existing 0.999 tolerance for 29.97-style rates).
- Fall back to the first resolution-matching format with its first supported range when no fps match exists, instead of leaving a null/mismatched pair.
- `lock()`: set `self.locked = true` after a successful `lockForConfiguration` so `unlock()` (guarded by `self.locked`) actually calls `unlockForConfiguration`. Previously the flag was never set and the device stayed configuration-locked. This changes `lock(&self)` to `lock(&mut self)`; the only in-tree caller (`set_all`) already takes `&mut self`.

## Testing

- `cargo check` on `nokhwa-bindings-macos` (macOS 26, Apple Silicon): compiles; no new warnings.
- Hardware: Logitech USB webcam (VID 0x046D) that reproducibly aborted on `Camera::new()` with `RequestedFormatType::AbsoluteHighestResolution` now opens at 1280x960, streams frames continuously, and delivers full-resolution stills. A MacBook Air built-in camera and an iPhone Continuity camera still enumerate as before (open not re-tested on those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
