### PR TITLE
fix(macos): pair compatible format/range in set_all

### DIFF
--- a/nokhwa-bindings-macos/src/lib.rs
+++ b/nokhwa-bindings-macos/src/lib.rs
@@ -1058,6 +1058,10 @@ mod internal {
                             break;
                         }
                     }
+                    // avoid pairing activeFormat with a range from a different format
+                    if !selected_range.is_null() {
+                        break;
+                    }
                 }
             }
             if selected_range.is_null() || selected_format.is_null() {


### PR DESCRIPTION
Previously, when a camera advertises the requested resolution under multiple formats (e.g. a UVC camera exposing 720p at both 30fps and 5fps), the outer loop overwrote  for each
resolution-matching format while  was left pointing at an earlier format's frame rate. The resulting activeFormat + activeVideoMinFrameDuration mismatch made AVFoundation throw NSInvalidArgumentException, which unwinds through nokhwa's non-unwinding objc exception bridge and hard-aborts the process.

Break out of the loop as soon as a format provides a frame-rate range compatible with the requested fps, so selected_format and selected_range always come from the same AVCaptureDeviceFormat.

---

(appended)

I just realized this duplicates #248, which fixes the same root cause (#247) and is already open. Sorry for the overlap.

Mine is intentionally minimal (a one-line break once a compatible format/range pair is found), so feel free to close this PR if #248 is preferable. No hard feelings either way.